### PR TITLE
Improvement after team feedbacks

### DIFF
--- a/products/sds/inventories/n-nodes/group_vars/oioswift.yml
+++ b/products/sds/inventories/n-nodes/group_vars/oioswift.yml
@@ -1,5 +1,12 @@
 ---
 openio_oioswift_bind_interface:  "{{ openio_bind_interface }}"
 openio_oioswift_sds_proxy_namespace: "{{ namespace }}"
+# Keystoneauth
 openio_oioswift_pipeline: "{{ pipeline_keystone }}"
+
+# Tempauth (when there's no node in the group "keystone")
+#openio_oioswift_pipeline: "{{ pipeline_tempauth }}"
+#openio_oioswift_filter_tempauth:
+#  use: "egg:swift#tempauth"
+#  user_demo_demo: "DEMO_PASS .admin"
 ...

--- a/products/sds/inventories/n-nodes/group_vars/openio.yml
+++ b/products/sds/inventories/n-nodes/group_vars/openio.yml
@@ -19,6 +19,7 @@ openio_bind_interface: "{{ ansible_default_ipv4.alias }}"
 openio_database_root_password: '#qeunovlhkojkDyzdllsdfmdoct794'
 openio_database_keystone_password: '9895bPievwmcvFqpujqixyhEcbJs_2'
 
+openio_keystone_enable: "{{ groups['keystone'] | length > 0 | bool }}"
 openio_keystone_admin_password: ADMIN_PASS
 openio_keystone_swift_password: SWIFT_PASS
 openio_keystone_demo_password: DEMO_PASS

--- a/products/sds/inventories/n-nodes/group_vars/openio.yml
+++ b/products/sds/inventories/n-nodes/group_vars/openio.yml
@@ -4,7 +4,6 @@ openio_sds_release: "18.04"
 
 # Namespace
 namespace: OPENIO
-namespace_conscience_address: "{{ groups['openio_conscience'] | map('extract',hostvars,['ansible_' ~ openio_bind_interface,'ipv4','address']) | list | first }}"
 namespace_meta1_digits: "2"
 # Replication
 namespace_storage_policy: THREECOPIES

--- a/products/sds/inventories/standalone/group_vars/openio.yml
+++ b/products/sds/inventories/standalone/group_vars/openio.yml
@@ -4,7 +4,6 @@ openio_sds_release: "18.04"
 
 # Namespace
 namespace: OPENIO
-namespace_conscience_address: "{{ groups['openio_conscience'] | map('extract',hostvars,['ansible_' ~ openio_bind_interface,'ipv4','address']) | list | first }}"
 #namespace_meta1_digits: "2"
 # Replication
 namespace_storage_policy: SINGLE

--- a/products/sds/inventories/standalone/group_vars/openio.yml
+++ b/products/sds/inventories/standalone/group_vars/openio.yml
@@ -22,6 +22,7 @@ openio_bind_interface: "{{ ansible_default_ipv4.alias }}"
 openio_database_root_password: '#qeunovlhkojkDyzdllsdfmdoct794'
 openio_database_keystone_password: '9895bPievwmcvFqpujqixyhEcbJs_2'
 
+openio_keystone_enable: "{{ groups['keystone'] | length > 0 | bool }}"
 openio_keystone_admin_password: ADMIN_PASS
 openio_keystone_swift_password: SWIFT_PASS
 openio_keystone_demo_password: DEMO_PASS

--- a/products/sds/playbooks/checks.yml
+++ b/products/sds/playbooks/checks.yml
@@ -106,15 +106,28 @@
         - ansible_os_family == 'RedHat'
         - not openio_manage_os_requirement
 
+    - name: Check AppArmor status
+      command: 'apparmor_status'
+      register: _apparmor_status
+      changed_when: false
+      failed_when: false
+
     - name: Disable AppArmor
-      service:
-        name: apparmor
-        state: stopped
-        enabled: false
+      command: "{{ item }}"
+      register: _disable_apparmor
+      with_items:
+        - "service apparmor stop"
+        - "service apparmor teardown"
+        - "update-rc.d -f apparmor remove"
       when:
         - ansible_os_family == 'Debian'
-        - ansible_apparmor.status != 'disabled'
+        - _apparmor_status.rc == 0
         - openio_manage_os_requirement
+
+    - name: Check new AppArmor status
+      setup:
+        filter: "ansible_apparmor"
+      when: _disable_apparmor.changed
 
     - name: Stop if AppArmor activated
       assert:

--- a/products/sds/playbooks/install_basic_needs.yml
+++ b/products/sds/playbooks/install_basic_needs.yml
@@ -17,5 +17,4 @@
     - name: Install iproute
       package:
         name: "{{ 'iproute' if ansible_os_family == 'RedHat' else 'iproute2' }}"
-      
 ...

--- a/products/sds/playbooks/oioswift.yml
+++ b/products/sds/playbooks/oioswift.yml
@@ -13,6 +13,12 @@
   environment: "{{ openio_environment }}"
 
   roles:
+    - role: memcached
+      openio_memcached_namespace: "{{ namespace }}"
+      openio_memcached_gridinit_dir: "/etc/gridinit.d/"
+      openio_memcached_gridinit_file_prefix: "{{ namespace }}-"
+      when: not openio_keystone_enable
+
     - role: oioswift
       openio_oioswift_namespace: "{{ namespace }}"
       openio_oioswift_gridinit_dir: "/etc/gridinit.d/"

--- a/products/sds/playbooks/openiosds.yml
+++ b/products/sds/playbooks/openiosds.yml
@@ -6,6 +6,10 @@
   gather_facts: true
   environment: "{{ openio_environment }}"
 
+  pre_tasks:
+    - set_fact:
+        openio_address: "{{ hostvars[inventory_hostname]['ansible_' + openio_bind_interface]['ipv4']['address'] }}"
+
   roles:
     - role: openio-sds
       openio_sds_version: "{{ openio_sds_release }}"
@@ -13,12 +17,12 @@
       openio_storage_policy: "{{ namespace_storage_policy }}"
       openio_sds_sysctl_managed: "{{ openio_manage_sysctl }}"
       openio_meta1_digits: "{{ namespace_meta1_digits }}"
-      openio_zk_cluster_ip: "{{ [] if groups.all | length == 1 else groups['zookeeper'] | map('extract',hostvars,['ansible_' ~ openio_bind_interface,'ipv4','address']) | list  }}"
-      openio_redis_cluster_ip: "{{ groups['openio_redis_cluster'] | map('extract',hostvars,['ansible_' ~ openio_bind_interface,'ipv4','address']) | list }}"
-      conscience_ip: "{{ namespace_conscience_address }}"
+      openio_zk_cluster_ip: "{{ [] if groups.all | length == 1 else groups['zookeeper'] | map('extract',hostvars,['openio_address']) | list }}"
+      openio_redis_cluster_ip: "{{ groups['openio_redis_cluster'] | map('extract',hostvars,['openio_address']) | list }}"
+      conscience_ip: "{{ groups['openio_conscience'] | map('extract',hostvars,['openio_address']) | list | first }}"
       openio_bootstrap: "{{ openio_ecd }}"
-      openio_network_private_ipaddress: "{{ hostvars[inventory_hostname]['ansible_' ~ openio_bind_interface]['ipv4']['address'] }}"
-      openio_network_public_ipaddress: "{{ hostvars[inventory_hostname]['ansible_' ~ openio_bind_interface]['ipv4']['address'] }}"
+      openio_network_private_ipaddress: "{{ openio_address }}"
+      openio_network_public_ipaddress: "{{ openio_address }}"
       openio_sds_default_account: "{{ default_account }}"
       openio_chunk_size: "{{ (namespace_chunk_size_megabytes | int) * 1024 * 1024 }}"
       openio_zk_inventory_group_name: zookeeper

--- a/products/sds/playbooks/postinstall.yml
+++ b/products/sds/playbooks/postinstall.yml
@@ -7,65 +7,77 @@
 
   tasks:
 
-    - name: Install AWS client
-      package:
-        name: awscli
+    - name: AWS with keystone
+      block:
+        - name: Install AWS client
+          package:
+            name: awscli
 
-    - name: Creating AWS credentials
-      command: openstack ec2 credentials create -f json
-      register: cred
-      environment:
-        OS_PROJECT_DOMAIN_NAME: Default
-        OS_USER_DOMAIN_NAME: Default
-        OS_PROJECT_NAME: demo
-        OS_USERNAME: demo
-        OS_PASSWORD: "{{ openio_keystone_demo_password }}"
-        OS_AUTH_URL: "http://{{ hostvars[inventory_hostname]['ansible_' + openio_keystone_bind_interface]['ipv4']['address'] }}:35357"
-        OS_IDENTITY_API_VERSION: 3
-        OS_IMAGE_API_VERSION: 2
+        - name: Creating AWS credentials
+          command: openstack ec2 credentials create -f json
+          register: cred
+          environment:
+            OS_PROJECT_DOMAIN_NAME: Default
+            OS_USER_DOMAIN_NAME: Default
+            OS_PROJECT_NAME: demo
+            OS_USERNAME: demo
+            OS_PASSWORD: "{{ openio_keystone_demo_password }}"
+            OS_AUTH_URL: "http://{{ hostvars[inventory_hostname]['ansible_' + openio_keystone_bind_interface]['ipv4']['address'] }}:35357"
+            OS_IDENTITY_API_VERSION: 3
+            OS_IMAGE_API_VERSION: 2
    
-    - name: Create .aws folder
-      file:
-        path: /root/.aws
-        state: directory
-        mode: 0750
+        - name: Create .aws folder
+          file:
+            path: /root/.aws
+            state: directory
+            mode: 0750
 
-    - name: Set aws credentials
-      no_log: true
-      ignore_errors: true
-      copy:
-        dest: /root/.aws/credentials
-        content: |
-          [default]
-          aws_access_key_id = {{ (( cred.stdout | from_json ) | selectattr('Field', 'match', 'access') | list | first )['Value'] }}
-          aws_secret_access_key = {{ (( cred.stdout | from_json ) | selectattr('Field', 'match', 'secret') | list | first )['Value'] }} 
-      register: aws_cred_file
+        - name: Set aws credentials
+          no_log: true
+          ignore_errors: true
+          copy:
+            dest: /root/.aws/credentials
+            content: |
+              [default]
+              aws_access_key_id = {{ (( cred.stdout | from_json ) | selectattr('Field', 'match', 'access') | list | first )['Value'] }}
+              aws_secret_access_key = {{ (( cred.stdout | from_json ) | selectattr('Field', 'match', 'secret') | list | first )['Value'] }} 
+          register: aws_cred_file
 
-    - name: Set aws credentials
-      no_log: true
-      copy:
-        dest: /root/.aws/credentials
-        content: |
-          [default]
-          aws_access_key_id = {{ ( cred.stdout | from_json )['access'] }}
-          aws_secret_access_key = {{ ( cred.stdout | from_json )['secret'] }}
-      when: aws_cred_file | failed
-          
-    - name: Configure environment for test
+        - name: Set aws credentials
+          no_log: true
+          copy:
+            dest: /root/.aws/credentials
+            content: |
+              [default]
+              aws_access_key_id = {{ ( cred.stdout | from_json )['access'] }}
+              aws_secret_access_key = {{ ( cred.stdout | from_json )['secret'] }}
+          when: aws_cred_file | failed
+
+        - name: Configure environment for AWS test
+          no_log: true
+          copy:
+            dest: "{{ item.path }}"
+            content: "{{ item.content }}"
+          with_items: 
+            - path : /root/.aws/config
+              content: |
+                [default]
+                region = RegionOne
+                s3 =
+                  signature_version = s3
+
+      when: openio_keystone_enable
+
+    - name: Configure environment for OPENIO test
       no_log: true
       copy:
         dest: "{{ item.path }}"
         content: "{{ item.content }}"
       with_items: 
-        - path : /root/.aws/config
-          content: |
-            [default]
-            region = RegionOne
-            s3 =
-              signature_version = s3
         - path: /etc/profile.d/openio.sh
           content: |
             export OIO_NS={{ namespace }}
+            {% if openio_keystone_enable %}
             export OS_PROJECT_DOMAIN_NAME=Default
             export OS_USER_DOMAIN_NAME=Default
             export OS_PROJECT_NAME=demo
@@ -74,6 +86,7 @@
             export OS_AUTH_URL=http://{{ hostvars[inventory_hostname]['ansible_' + openio_keystone_bind_interface]['ipv4']['address'] }}:35357
             export OS_IDENTITY_API_VERSION=3
             export OS_IMAGE_API_VERSION=2
+            {% endif %}
 
     - name: Add script for tests in /root/checks.sh
       template:

--- a/products/sds/requirements.yml
+++ b/products/sds/requirements.yml
@@ -36,7 +36,7 @@
   name: account
 
 - src: https://github.com/open-io/ansible-role-openio-zookeeper
-  version: a0cb4fc3d6b2210c605c6c99fe5df1fa6077cb01
+  version: f48fa03a9a32aac08895afa7cba1a6d10883a6c9
   name: zookeeper
 
 - src: https://github.com/geerlingguy/ansible-role-ntp

--- a/products/sds/templates/checks.sh.j2
+++ b/products/sds/templates/checks.sh.j2
@@ -44,9 +44,13 @@ openio container delete MY_CONTAINER --oio-account MY_ACCOUNT
 echo --
 
 echo
-
+{% if groups['keystone'] | length > 0 %}
 echo '------'
 echo '## AWS'
+
+echo -e $YELLOW AWSCli credentials used. $NC
+cat /root/.aws/credentials
+echo --
 
 echo -e $YELLOW Create a bucket 'mybucket'. $NC
 aws --endpoint-url http://{{ hostvars[inventory_hostname]['ansible_' + openio_keystone_bind_interface]['ipv4']['address'] }}:6007 --no-verify-ssl s3 mb s3://mybucket
@@ -72,5 +76,7 @@ echo --
 echo -e $YELLOW Delete your empty bucket. $NC
 aws --endpoint-url http://{{ hostvars[inventory_hostname]['ansible_' + openio_keystone_bind_interface]['ipv4']['address'] }}:6007 --no-verify-ssl s3 rb s3://mybucket
 echo
+
+{% endif %}
 
 echo Done

--- a/products/sds/templates/checks.sh.j2
+++ b/products/sds/templates/checks.sh.j2
@@ -44,7 +44,7 @@ openio container delete MY_CONTAINER --oio-account MY_ACCOUNT
 echo --
 
 echo
-{% if groups['keystone'] | length > 0 %}
+{% if openio_keystone_enable %}
 echo '------'
 echo '## AWS'
 


### PR DESCRIPTION
* Manage non-homogeneous interfaces more easily 
```
$ grep -ri openio_bind_interface inventories/n-nodes/{host_vars/node1.yml,group_vars/openio.yml}
inventories/n-nodes/host_vars/node1.yml:openio_bind_interface: eth0
inventories/n-nodes/group_vars/openio.yml:openio_bind_interface: "{{ ansible_default_ipv4.alias }}"
inventories/n-nodes/group_vars/openio.yml:#openio_bind_interface: "bond0"
```
* Display (for information) AWS credentias used during the test

* Manage use-case without keystone (so without aws creds)

* Disable Apparmor