### PR TITLE
Roundtrip: manage env_vars and NO_PROXY

### DIFF
--- a/products/sds/templates/checks.sh.j2
+++ b/products/sds/templates/checks.sh.j2
@@ -4,6 +4,15 @@
 YELLOW="\e[33m"
 NC="\e[39m"
 
+# Environment variables
+{% for key in openio_environment.keys() %}
+export {{ key }}={{ openio_environment[key] }}
+{% endfor %}
+{% if openio_environment.http_proxy is defined or openio_environment.https_proxy is defined %}
+export NO_PROXY={{ hostvars[inventory_hostname]['openio_bind_address'] }}
+{% endif %}
+# End environment variables
+
 echo '## OPENIO'
 . /etc/profile.d/openio.sh
 


### PR DESCRIPTION
```shell
[root@48a2c039bac4 ~]# cat checks.sh
#!/bin/bash
#OpenIO managed

YELLOW="\e[33m"
NC="\e[39m"

# Environment variables
export https_proxy=http://foo.bar:3128
export NO_PROXY=172.17.0.2
# End environment variables

echo '## OPENIO'
. /etc/profile.d/openio.sh
```