### PR TITLE
CHANGE(SDS): Multi-conscience activation + Conf updates to decrease detection times when a node is down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
     done
 
   # loss of 1 server
-  #- docker stop $TRINODE_ID1
-  #- sleep 60
-  #- SUT_IP=172.17.0.33 ./docker-tests/functional-tests.sh
+  - docker stop $TRINODE_ID1
+  - sleep 5 
+  - SUT_IP=172.17.0.33 ./docker-tests/functional-tests.sh
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,6 @@ script:
 
   # loss of 1 server
   - docker stop $TRINODE_ID1
-  - sleep 5 
+  - sleep 30 
   - SUT_IP=172.17.0.33 ./docker-tests/functional-tests.sh
 ...

--- a/products/sds/docker-tests/conscience.bats
+++ b/products/sds/docker-tests/conscience.bats
@@ -11,13 +11,13 @@ get_ID_node() {
   #for i in $(docker ps -aq); do
   #  export SUT_ID=$(docker inspect $i| grep -B400 ${SUT_IP}|grep Hostname\" | uniq| sed -e 's@.*"\(.*\)",@\1@')
   #done
-  if [[ "$SUT_IP" == "172.17.0.2" ]]; then export SUT_ID=${TRINODE_ID1}; fi 
-  if [[ "$SUT_IP" == "172.17.0.3" ]]; then export SUT_ID=${TRINODE_ID2}; fi 
-  if [[ "$SUT_IP" == "172.17.0.33" ]]; then export SUT_ID=${TRINODE_ID3}; fi 
+  if [[ "$SUT_IP" == "172.17.0.2" ]]; then export SUT_ID=${TRINODE_ID1}; fi
+  if [[ "$SUT_IP" == "172.17.0.3" ]]; then export SUT_ID=${TRINODE_ID2}; fi
+  if [[ "$SUT_IP" == "172.17.0.33" ]]; then export SUT_ID=${TRINODE_ID3}; fi
 }
 
 setup() {
-  run_only_test
+  #run_only_test
   get_ID_node
 }
 

--- a/products/sds/docker-tests/inventory.yml
+++ b/products/sds/docker-tests/inventory.yml
@@ -58,6 +58,7 @@ all:
       vars:
         namespace: OPENIO
         namespace_storage_policy: "THREECOPIES"
+        openio_conscience_multiple_enable: true
 
         openio_bind_interface: '{{ ansible_default_ipv4.alias }}'
         openio_bind_address: '{{ ansible_default_ipv4.address }}'
@@ -106,14 +107,18 @@ all:
 
     conscience:
       hosts:
-        #node1: {}
-        #node2: {}
+        node1: {}
+        node2: {}
         node3: {}
+      vars:
+        openio_conscience_services_common_timeout: 5
 
     conscience-agent:
       children:
         backs: {}
-
+      vars:
+       openio_conscienceagent_check_interval: 1
+ 
     ecd:
       children:
         backs: {}
@@ -147,6 +152,9 @@ all:
         openio: {}
       vars:
         openio_namespace_conscience_url: "{{ hostvars[groups['conscience'][0]]['openio_bind_address'] }}:6000"
+        openio_namespace_options:
+        - "proxy.period.cs.upstream=1"
+        - "proxy.period.cs.downstream=2"
 
     oio-blob-indexer:
       children:

--- a/products/sds/docker-tests/inventory.yml
+++ b/products/sds/docker-tests/inventory.yml
@@ -117,8 +117,8 @@ all:
       children:
         backs: {}
       vars:
-       openio_conscienceagent_check_interval: 1
- 
+        openio_conscienceagent_check_interval: 1
+
     ecd:
       children:
         backs: {}
@@ -151,10 +151,9 @@ all:
       children:
         openio: {}
       vars:
-        openio_namespace_conscience_url: "{{ hostvars[groups['conscience'][0]]['openio_bind_address'] }}:6000"
         openio_namespace_options:
-        - "proxy.period.cs.upstream=1"
-        - "proxy.period.cs.downstream=2"
+          - "proxy.period.cs.upstream=1"
+          - "proxy.period.cs.downstream=2"
 
     oio-blob-indexer:
       children:

--- a/products/sds/inventory.yml
+++ b/products/sds/inventory.yml
@@ -53,7 +53,7 @@ all:
         namespace: OPENIO
         namespace_storage_policy: "THREECOPIES"
         openio_conscience_multiple_enable: true
-        
+
         openio_bind_interface: '{{ ansible_default_ipv4.alias }}'
         openio_bind_address: '{{ ansible_default_ipv4.address }}'
 
@@ -95,7 +95,7 @@ all:
       children:
         backs: {}
       vars:
-       openio_conscienceagent_check_interval: 1
+        openio_conscienceagent_check_interval: 1
 
     ecd:
       children:
@@ -129,10 +129,9 @@ all:
       children:
         openio: {}
       vars:
-        openio_namespace_conscience_url: "{{ hostvars[groups['conscience'][0]]['openio_bind_address'] }}:6000"
         openio_namespace_options:
-        - "proxy.period.cs.upstream=1"
-        - "proxy.period.cs.downstream=2" 
+          - "proxy.period.cs.upstream=1"
+          - "proxy.period.cs.downstream=2"
 
     oio-blob-indexer:
       children:

--- a/products/sds/inventory.yml
+++ b/products/sds/inventory.yml
@@ -52,7 +52,8 @@ all:
       vars:
         namespace: OPENIO
         namespace_storage_policy: "THREECOPIES"
-
+        openio_conscience_multiple_enable: true
+        
         openio_bind_interface: '{{ ansible_default_ipv4.alias }}'
         openio_bind_address: '{{ ansible_default_ipv4.address }}'
 
@@ -84,11 +85,17 @@ all:
 
     conscience:
       hosts:
+        node1: {}
+        node2: {}
         node3: {}
+      vars:
+        openio_conscience_services_common_timeout: 5
 
     conscience-agent:
       children:
         backs: {}
+      vars:
+       openio_conscienceagent_check_interval: 1
 
     ecd:
       children:
@@ -123,6 +130,9 @@ all:
         openio: {}
       vars:
         openio_namespace_conscience_url: "{{ hostvars[groups['conscience'][0]]['openio_bind_address'] }}:6000"
+        openio_namespace_options:
+        - "proxy.period.cs.upstream=1"
+        - "proxy.period.cs.downstream=2" 
 
     oio-blob-indexer:
       children:


### PR DESCRIPTION
 ##### SUMMARY
Activation of the multi conscience, which allows to stop any node of the cluster (3 nodes cluster)

SDS configuration update to allow the Conscience service to be more quickly aware that a service is unavailable.
The goal is to reduce the detection time when a node is down.
Update of the namespace, conscience and conscience-agent configuration

Update the Travis tests to simulate the loss of a server

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Steps to activate Multi-conscience :
1- in inventory.yml :
	 - openio_conscience_multiple_enable: true
	 - add the 3 nodes in the conscience configuration
2- use the openio_namespace_overwrite option to allow the namespace update :
	`ansible-playbook -i inventory.yml main.yml -e "openio_maintenance_mode=false" -e "openio_namespace_overwrite=true"`